### PR TITLE
ETD-206: proquest id

### DIFF
--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -97,6 +97,10 @@ def add_holdings(json_message):
         logger.debug("message")
         logger.debug(json_message)
         current_span.add_event(json.dumps(json_message))
+        if 'identifier' in json_message:
+            proquest_identifier = json_message['identifier']
+            current_span.set_attribute("identifier", proquest_identifier)
+            logger.debug("processing id: " + str(proquest_identifier))
         if FEATURE_FLAGS in json_message:
             feature_flags = json_message[FEATURE_FLAGS]
             if DRS_HOLDING_FEATURE_FLAG in feature_flags and \
@@ -144,6 +148,12 @@ def invoke_hello_world(json_message):
             new_message[FEATURE_FLAGS] = json_message[FEATURE_FLAGS]
             current_span.add_event("FEATURE FLAGS FOUND")
             current_span.add_event(json.dumps(json_message[FEATURE_FLAGS]))
+
+        if 'identifier' in json_message:
+            proquest_identifier = json_message['identifier']
+            new_message["identifier"] = proquest_identifier
+            current_span.set_attribute("identifier", proquest_identifier)
+            logger.debug("processing id: " + str(proquest_identifier))
 
         # If only unit testing, return the message and
         # do not trigger the next task.

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -10,12 +10,17 @@ class TestTasksClass():
                 'dash_feature_flag': "off",
                 'alma_feature_flag': "off",
                 'send_to_drs_feature_flag': "off",
-                'drs_holding_record_feature_flag': "off"}}
+                'drs_holding_record_feature_flag': "off"},
+                "identifier": "30522803"}
         retval = tasks.add_holdings(message)
         assert "hello" in retval
         assert "feature_flags" in retval
+        assert "identifier" in retval
+        assert retval["identifier"] == "30522803"
 
     def test_add_holdings_no_feature_flags(self):
-        message = {"unit_test": "true"}
+        message = {"unit_test": "true", "identifier": "30522803"}
         retval = tasks.add_holdings(message)
         assert "hello" in retval
+        assert "identifier" in retval
+        assert retval["identifier"] == "30522803"


### PR DESCRIPTION
**Trace on ProQuest ID**
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/ETD-206

# What does this Pull Request do?
A brief description of what the intended result of the PR will be and/or what problem it solves.
Adds ProQuest ID to traces

# How should this be tested?

this has been deployed to dev.
to test on dev:
1) run the itest https://ltsds-cloud-dev-1.lib.harvard.edu:10610/integration
2) check jaeger dashboard http://ltsds-cloud-dev-1.lib.harvard.edu:16686/  then look at most recent trace and check the tags pulldown in a method. you should see "identifier = PROQUEST_ID".  you can also search for it on the dashboard on the identifier field to find methods.

to test locally:
1) run pytest unit test to validate method
or
1) set up all containers locally including itest
2) run itest locally (http://localhost:16686/)
3) check jaeger dashboard http://ltsds-cloud-dev-1.lib.harvard.edu:16686/  then look at most recent trace and check the tags pulldown in a method. you should see "identifier = PROQUEST_ID".  you can also search for it on the dashboard on the identifier field to find methods.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? y
- integration tests? y

# Interested parties
Tag (@ mention) interested parties: @awoods 
